### PR TITLE
improve SyncTLSStream

### DIFF
--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -29,7 +29,7 @@ class OverallTimeout:
     """
 
     def __init__(self, timeout: typing.Optional[float] = None) -> None:
-        self._timeout = timeout or None  # Replaces `0` with `None`
+        self.timeout = timeout or None  # Replaces `0` with `None`
         self._start: typing.Optional[float] = None
 
     def __enter__(self) -> "OverallTimeout":
@@ -42,15 +42,7 @@ class OverallTimeout:
         self, exc_type: typing.Any, exc_val: typing.Any, exc_tb: typing.Any
     ) -> None:
         if self.timeout is not None:
-            self._timeout -= perf_counter() - self._start
-
-    @property
-    def timeout(self):
-        return self._timeout
-
-    @timeout.setter
-    def timeout(self, value: typing.Optional[float]):
-        self._timeout = value or None
+            self.timeout -= perf_counter() - self._start
 
 
 class SyncTLSStream(NetworkStream):

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -113,7 +113,7 @@ class SyncTLSStream(NetworkStream):
         exc_map: ExceptionMapping = {socket.timeout: WriteTimeout, OSError: WriteError}
         with map_exceptions(exc_map):
             while buffer:
-                nsent = self._perform_io(partial(self.ssl_obj.write), buffer, timeout)
+                nsent = self._perform_io(partial(self.ssl_obj.write, buffer), timeout)
                 buffer = buffer[nsent:]
 
     def close(self) -> None:

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -41,9 +41,8 @@ class OverallTimeout:
     def __exit__(
         self, exc_type: typing.Any, exc_val: typing.Any, exc_tb: typing.Any
     ) -> None:
-        if self.timeout is None:
-            return
-        self._timeout -= perf_counter() - self._start
+        if self.timeout is not None:
+            self._timeout -= perf_counter() - self._start
 
     @property
     def timeout(self):
@@ -83,7 +82,7 @@ class SyncTLSStream(NetworkStream):
         ret = None
         while True:
             errno = None
-            try
+            try:
                 ret = func()
             except (ssl.SSLWantReadError, ssl.SSLWantWriteError) as e:
                 errno = e.errno

--- a/httpcore/_backends/sync.py
+++ b/httpcore/_backends/sync.py
@@ -29,7 +29,7 @@ class OverallTimeout:
     """
 
     def __init__(self, timeout: typing.Optional[float] = None) -> None:
-        self.timeout = timeout  # Replaces `0` with `None`
+        self._timeout = timeout or None  # Replaces `0` with `None`
         self._start: typing.Optional[float] = None
 
     def __enter__(self) -> "OverallTimeout":


### PR DESCRIPTION
- `property setter` instead of `_expired` attribute.
- `partial` instead of `arg1`